### PR TITLE
CLEVA Fairness Perturbation

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -197,3 +197,4 @@ zstandard==0.18.0
 unidecode==1.3.6
 pypinyin==0.49.0
 jieba==0.42.1
+opencc==1.1.6

--- a/src/helm/benchmark/augmentations/cleva_perturbation.py
+++ b/src/helm/benchmark/augmentations/cleva_perturbation.py
@@ -10,6 +10,7 @@ import unidecode
 import pypinyin
 import jieba
 import jieba.posseg as pseg
+import opencc
 
 from helm.common.general import ensure_file_downloaded, ensure_directory_exists
 from helm.benchmark.scenarios.scenario import Input, Instance, Reference, Output
@@ -661,3 +662,26 @@ class ChinesePersonNamePerturbation(Perturbation):
             tags.append(flag)
 
         return tokens, tags
+
+
+class SimplifiedToTraditionalPerturbation(Perturbation):
+    """Individual fairness perturbation for Chinese simplified to Chinese traditional."""
+
+    name: str = "simplified_to_traditional"
+
+    should_perturb_references: bool = True
+
+    @property
+    def description(self) -> PerturbationDescription:
+        return PerturbationDescription(name=self.name, fairness=True)
+
+    def __init__(
+        self,
+    ):
+        """Initialize the Chinese simplified to Chinese traditional perturbation."""
+        self.converter = opencc.OpenCC("s2t.json")
+
+    def perturb(self, text: str, rng: Random) -> str:
+        """Perform the perturbations on the provided text."""
+        perturbed_text: str = self.converter.convert(text)
+        return perturbed_text

--- a/src/helm/benchmark/augmentations/cleva_perturbation.py
+++ b/src/helm/benchmark/augmentations/cleva_perturbation.py
@@ -656,10 +656,10 @@ class ChinesePersonNamePerturbation(Perturbation):
         """Perform the word segmentation and POS tagging on the text."""
         tokens: List[str] = []
         tags: List[str] = []
-        output = pseg.cut(text)
-        for token, flag in output:
+        output: Tuple[List[str], List[str]] = pseg.cut(text)
+        for token, tag in output:
             tokens.append(token)
-            tags.append(flag)
+            tags.append(tag)
 
         return tokens, tags
 

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -582,6 +582,13 @@ def cleva_person_name(
     )
 
 
+def simplified_to_traditional() -> PerturbationSpec:
+    return PerturbationSpec(
+        class_name="helm.benchmark.augmentations.cleva_perturbation.SimplifiedToTraditionalPerturbation",
+        args={},
+    )
+
+
 # Specifies the data augmentations that we're interested in trying out.
 # Concretely, this is a mapping from the name (which is specified in a conf
 # file or the CLI) to a list of options to try, where each option is a list of perturbations.
@@ -755,6 +762,7 @@ PERTURBATION_SPECS_DICT: Dict[str, Dict[str, List[PerturbationSpec]]] = {
                 target_class={"gender": "female"},
                 preserve_gender=True,
             ),
+            simplified_to_traditional(),
         ]
     },
 }

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -773,6 +773,20 @@ PERTURBATION_SPECS_DICT: Dict[str, Dict[str, List[PerturbationSpec]]] = {
             mandarin_to_cantonese(),
         ]
     },
+    "cleva": {
+        "cleva": [
+            cleva_mild_mix(),
+            cleva_gender(mode="pronouns", prob=1.0, source_class="male", target_class="female"),
+            cleva_person_name(
+                prob=1.0,
+                source_class={"gender": "male"},
+                target_class={"gender": "female"},
+                preserve_gender=True,
+            ),
+            simplified_to_traditional(),
+            mandarin_to_cantonese(),
+        ]
+    },
 }
 
 

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -548,6 +548,40 @@ def cleva_mild_mix() -> PerturbationSpec:
     )
 
 
+def cleva_gender(
+    mode: str,
+    prob: float,
+    source_class: str,
+    target_class: str,
+) -> PerturbationSpec:
+    return PerturbationSpec(
+        class_name="helm.benchmark.augmentations.cleva_perturbation.ChineseGenderPerturbation",
+        args={
+            "mode": mode,
+            "prob": prob,
+            "source_class": source_class,
+            "target_class": target_class,
+        },
+    )
+
+
+def cleva_person_name(
+    prob: float,
+    source_class: Dict[str, str],
+    target_class: Dict[str, str],
+    preserve_gender: bool = True,
+) -> PerturbationSpec:
+    return PerturbationSpec(
+        class_name="helm.benchmark.augmentations.cleva_perturbation.ChinesePersonNamePerturbation",
+        args={
+            "prob": prob,
+            "source_class": source_class,
+            "target_class": target_class,
+            "preserve_gender": preserve_gender,
+        },
+    )
+
+
 # Specifies the data augmentations that we're interested in trying out.
 # Concretely, this is a mapping from the name (which is specified in a conf
 # file or the CLI) to a list of options to try, where each option is a list of perturbations.
@@ -712,6 +746,17 @@ PERTURBATION_SPECS_DICT: Dict[str, Dict[str, List[PerturbationSpec]]] = {
         ]
     },
     "cleva_robustness": {"robustness": [cleva_mild_mix()]},
+    "cleva_fairness": {
+        "fairness": [
+            cleva_gender(mode="pronouns", prob=1.0, source_class="male", target_class="female"),
+            cleva_person_name(
+                prob=1.0,
+                source_class={"gender": "male"},
+                target_class={"gender": "female"},
+                preserve_gender=True,
+            ),
+        ]
+    },
 }
 
 

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -589,6 +589,13 @@ def simplified_to_traditional() -> PerturbationSpec:
     )
 
 
+def mandarin_to_cantonese() -> PerturbationSpec:
+    return PerturbationSpec(
+        class_name="helm.benchmark.augmentations.cleva_perturbation.MandarinToCantonesePerturbation",
+        args={},
+    )
+
+
 # Specifies the data augmentations that we're interested in trying out.
 # Concretely, this is a mapping from the name (which is specified in a conf
 # file or the CLI) to a list of options to try, where each option is a list of perturbations.
@@ -763,6 +770,7 @@ PERTURBATION_SPECS_DICT: Dict[str, Dict[str, List[PerturbationSpec]]] = {
                 preserve_gender=True,
             ),
             simplified_to_traditional(),
+            mandarin_to_cantonese(),
         ]
     },
 }


### PR DESCRIPTION
Add CLEVA fairness perturbations following HELM's implementations and setup (if any):
1. `ChineseGenderPerturbation` (follows [HELM Gender Perturbation](https://github.com/stanford-crfm/helm/blob/main/src/helm/benchmark/augmentations/gender_perturbation.py))
2. `ChinesePersonNamePerturbation` (follows [HELM Person Name Perturbation](https://github.com/stanford-crfm/helm/blob/main/src/helm/benchmark/augmentations/person_name_perturbation.py), but only has `gender` category)
3. `SimplifiedToTraditionalPerturbation`
4. `MandarinToCantonesePerturbation`